### PR TITLE
Fixed losing custom domain after each commit. 

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,3 +28,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./html
+        cname: cardanocataly.st


### PR DESCRIPTION
This can be fixed in 2 ways. Either add a parameter to the workflow config
or put `CNAME` file in `./html` folder
I used the parameter in workflow, having CNAME file in folder could be better, more resilient and easier to find...